### PR TITLE
order output of accounts predictably

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.7.x
+- 1.9.x
 install: go get github.com/mitchellh/gox
 before_deploy: "make dist"
 deploy:


### PR DESCRIPTION
  - orders the output of events as per the accountMap friendly names
  - fix duplicates by ensuring unique slices
  - fix dependancy reference
  - bump version number for fix
  - push travis yml to go 1.9.x to support sort.Slice method
  - ref: https://github.com/aidan-/aws-cli-federator/issues/4