### PR TITLE
order output of accounts predictably

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.7.x
+- 1.9.x
 install: go get github.com/mitchellh/gox
 before_deploy: "make dist"
 deploy:

--- a/main.go
+++ b/main.go
@@ -10,11 +10,12 @@ import (
 	"os/user"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 
 	"github.com/aidan-/aws-cli-federator/federator"
+	"github.com/go-ini/ini"
 	"github.com/howeyc/gopass"
-	"gopkg.in/ini.v1"
 )
 
 type configuration struct {
@@ -179,23 +180,43 @@ func main() {
 		if len(roles) == 1 {
 			roleToAssume = roles[0]
 		} else {
-			accountMap, err := c.cfg.GetSection("account_map")
+			roleMap := make(map[string]federator.Role) // mapping of pretty names to roles
+			var printableRoles []string                // slice for sorting matched pretty names
+			var unmatchedRoles []string                // slice for sorting unmatched pretty names
+
+			// iterate over available roles to build up a map of 'printable role name' -> role arn
+			// capture the key names in string arrays for order sorting
+			accountMap, err := c.cfg.GetSection("account_map") // mapping of accountId's to pretty names
 			if err == nil {
-				for n, role := range roles {
+				for _, role := range roles {
 					if accountMap.HasKey(role.AccountId()) {
 						an := accountMap.Key(role.AccountId()).String()
-						fmt.Fprintf(os.Stderr, "%d) %s:role/%s\n", n+1, an, role.RoleName())
+						roleMap[fmt.Sprintf("%s:role/%s", an, role.RoleName())] = role
+						printableRoles = append(printableRoles, fmt.Sprintf("%s:role/%s", an, role.RoleName()))
 					} else {
-						fmt.Fprintf(os.Stderr, "%d) %s\n", n+1, role.RoleArn())
+						roleMap[fmt.Sprintf("%s", role.RoleArn())] = role
+						unmatchedRoles = append(unmatchedRoles, role.RoleArn())
 					}
 				}
 			} else {
-				for n, role := range roles {
-					fmt.Fprintf(os.Stderr, "%d) %s\n", n+1, role.RoleArn())
+				for _, role := range roles {
+					roleMap[fmt.Sprintf("%s", role.RoleArn())] = role
 				}
 			}
-			var i int
 
+			// sort the role keys alphabetically and append the unmatchedRoles to the printableRoles array to ensure they appear last
+			sort.Strings(printableRoles)
+			sort.Strings(unmatchedRoles)
+
+			for _, k := range unmatchedRoles {
+				printableRoles = append(printableRoles, k)
+			}
+
+			for n, r := range printableRoles {
+				fmt.Fprintf(os.Stderr, "%d) %s\n", n+1, r)
+			}
+
+			var i int // user selection
 			fmt.Fprintf(os.Stderr, "Enter the ID# of the role you want to assume: ")
 
 			_, err = fmt.Scanf("%d", &i)
@@ -209,7 +230,7 @@ func main() {
 				os.Exit(1)
 			}
 
-			roleToAssume = roles[i-1]
+			roleToAssume = roleMap[printableRoles[i-1]]
 		}
 	}
 


### PR DESCRIPTION
  - orders the output of events as per the accountMap friendly names
  - fix dependancy reference
  - bump version number for fix
  - push travis yml to go 1.9.x
  - Implement @aidan- 's diff to simplify output and reduce the extraneous loops
  - Fix up ordering using an unmatchedRoles array
  - Tested login to first matching role and last unmatched role successfully

ref: https://github.com/aidan-/aws-cli-federator/issues/4