### PR TITLE
[fix] allow authentication with multiple roles also without account map

### DIFF
--- a/main.go
+++ b/main.go
@@ -194,13 +194,14 @@ func main() {
 						roleMap[fmt.Sprintf("%s:role/%s", an, role.RoleName())] = role
 						printableRoles = append(printableRoles, fmt.Sprintf("%s:role/%s", an, role.RoleName()))
 					} else {
-						roleMap[fmt.Sprintf("%s", role.RoleArn())] = role
-						unmatchedRoles = append(unmatchedRoles, role.RoleArn())
+						roleMap[fmt.Sprintf("%s:role/%s", role.AccountId(), role.RoleName())] = role
+						unmatchedRoles = append(unmatchedRoles, fmt.Sprintf("%s:role/%s", role.AccountId(), role.RoleName()))
 					}
 				}
 			} else {
 				for _, role := range roles {
-					roleMap[fmt.Sprintf("%s", role.RoleArn())] = role
+					roleMap[fmt.Sprintf("%s:role/%s", role.AccountId(), role.RoleName())] = role
+					printableRoles = append(printableRoles, fmt.Sprintf("%s:role/%s", role.AccountId(), role.RoleName()))
 				}
 			}
 


### PR DESCRIPTION
Since introducing the account map ini section, the federator would not work if you had not specified this section in your config. This commit fixes it, printing the account ids instead of the alias.